### PR TITLE
fix: 修复指定水印容器的 position、opacity 均可以使水印不可见的问题

### DIFF
--- a/watermark.js
+++ b/watermark.js
@@ -122,7 +122,7 @@
       otdiv.id = defaultSettings.watermark_id;
       otdiv.setAttribute(
         'style',
-        'pointer-events: none !important; display: block !important; position: static !important; opacity: 1 !important'
+        'pointer-events: none !important; display: block !important; position: static !important; opacity: 1 !important; visibility: visible !important'
       );
       /*判断浏览器是否支持attachShadow方法*/
       if(typeof otdiv.attachShadow === 'function'){

--- a/watermark.js
+++ b/watermark.js
@@ -120,7 +120,10 @@
       otdiv =document.createElement('div');
       /*创建shadow dom*/
       otdiv.id = defaultSettings.watermark_id;
-      otdiv.setAttribute('style','pointer-events: none !important; display: block !important');
+      otdiv.setAttribute(
+        'style',
+        'pointer-events: none !important; display: block !important; position: static !important; opacity: 1 !important'
+      );
       /*判断浏览器是否支持attachShadow方法*/
       if(typeof otdiv.attachShadow === 'function'){
         /* createShadowRoot Deprecated. Not for use in new websites. Use attachShadow*/


### PR DESCRIPTION
胡乱测试的时候发现的，父容器的 position 和 opacity 没有锁定，指定前者可以将子元素定位到屏幕外面，指定后者可以让整个水印完全透明。
添加CSS的话，很多浏览器插件都能做（stylus之类的，我就是拿stylus添加CSS的时候发现可以隐藏水印的）。