### PR TITLE
引用js 报错了 提示 Uncaught SyntaxError: Identifier 'MutationObserver' has a…

### DIFF
--- a/watermark.js
+++ b/watermark.js
@@ -283,7 +283,7 @@
       }
     }
   };
-  const MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
+
   var watermarkDom = new MutationObserver(callback);
   var option = {
     'childList': true,


### PR DESCRIPTION
修复引用js 报错了 提示 Uncaught SyntaxError: Identifier 'MutationObserver' has already been declared 。